### PR TITLE
release: v4.0.0 + migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,9 @@ jobs:
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version-file: .nvmrc
-                  cache: 'npm'
+                  package-manager-cache: false
                   registry-url: 'https://registry.npmjs.org'
+            - run: npm install -g npm@latest
             - run: npm ci
             - run: npm run prepublishOnly
             - run: npm publish --ignore-scripts --provenance
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Commands
+
+```sh
+npm run build          # Compile TypeScript to ./out (runs clean first)
+npm run lint           # Run ESLint
+npm run lint:fix       # Run ESLint with auto-fix
+npm run test:types     # Type-check all repo TypeScript, including the built-package fixture
+npm run test:artifacts # Verify built entry points/export map behavior and npm pack contents
+npm test               # Full test suite: clean + lint + license check + build + type/artifact checks + vitest with coverage
+npx vitest run         # Run tests without the pre-steps (faster for iteration)
+npx vitest run __tests__/1.compare.equal.pdf.files.test.ts  # Run a single test file
+npm run clean          # Remove ./out, ./coverage, ./test-results, ./comparePdfOutput
+```
+
+Tests have a 90-second timeout (`vitest.config.mjs`) because PDF-to-PNG conversion is slow. Coverage thresholds are enforced (100% statements/lines/functions, 90% branches).
+
+## Architecture
+
+This is a small TypeScript library published to npm. Source lives in `src/`, compiled output goes to `out/` (the published artifact).
+
+**Data flow:** `comparePdf(actualPdf, expectedPdf, opts)` →
+
+1. Validates and normalizes inputs: `string`, `Buffer`, `ArrayBuffer`, or `SharedArrayBuffer`; string inputs can be constrained by `allowedInputRoot`
+2. Discovers rendered page numbers via `pdfToPng` metadata-only calls — **sequentially**, not in parallel (concurrent document renders corrupt the shared PDF.js worker state and can cause "Invalid page request" errors)
+3. Builds a page-number keyed comparison plan
+4. Renders only the needed pages, one page at a time, via `pdfToPng`
+5. Compares each rendered page pair via synchronous `comparePng` from `png-visual-compare`
+6. Returns `false` if any page exceeds the applicable threshold or if one side is missing a planned page
+
+**Key constraints:**
+
+- `pdfToPng` document renders must remain sequential. `Promise.all` causes "Invalid page request" errors when PDFs have different page counts due to shared PDF.js worker state.
+- Page rendering is intentionally bounded-memory: plan first, then render/compare per page instead of holding both full documents in memory.
+- Page comparison is still sequential even after upgrading to `png-visual-compare` 6.x. That dependency now exposes async/ported comparison entry points, but this library should not parallelize page comparison without a benchmark and safety review.
+- All caller-supplied filesystem roots (`allowedInputRoot`, `diffsOutputFolder`, `pdfToPngConvertOptions.outputFolder`) share a single sandbox-parity contract: non-empty string, must resolve to a directory when it already exists, and may not traverse a symbolic link at the leaf or any existing ancestor. The shared symlink-rejection + path-containment primitives live in `src/internal/securePath.ts` — keep CWE-59 / CWE-61 fixes consolidated there.
+- `pdfToPngConvertOptions.outputFolder` additionally takes library ownership of leaf-directory creation: the resolved path and the `actual/`/`expected/` namespace subdirectories are pre-created and re-asserted (`lstat`) to be real directories during normalization, closing the residual validate→render TOCTOU window (CWE-367) that the path walker cannot cover. Replicate that pattern for any future caller that lets a third-party writer create files inside a user-supplied folder.
+
+**`excludedAreas` matching:** entries in `ComparePdfOptions.excludedAreas` are matched to pages by their `pageNumber` field (1-based, not array index). An entry with `pageNumber: 1` applies to the first page regardless of its position in the array.
+
+**`ComparePngOptions` surface:** `comparePdf` forwards `excludedAreas`, `excludedAreaColor`, `diffFilePath`, and `throwErrorOnInvalidInputData` to `png-visual-compare`. The `ExcludedPageArea.matchingThreshold` field is still applied inside `comparePdf` as a per-page threshold override rather than being forwarded downstream.
+
+**Public API** (exported from `src/index.ts`):
+
+- `comparePdf(actualPdf: PdfInput, expectedPdf: PdfInput, opts?: ComparePdfOptions): Promise<boolean>`
+- `ComparePdfOptions` type
+- `PdfInput` type
+- `ExcludedPageArea` type
+
+**Dependencies:**
+
+- `pdf-to-png-converter` — renders PDF pages to PNG buffers using PDF.js plus prebuilt `@napi-rs/canvas` binaries (Node `>=24`)
+- `png-visual-compare` — pixel-level PNG comparison with exclusion zone support
+
+## Test Structure
+
+Tests are in `__tests__/` and use Vitest. Test PDFs are in `test-data/`. `tsconfig.json` is the workspace/dev config and includes all repo `.ts` files, including `__tests__/published-artifacts/consumer-types.ts`, which verifies the built package surface via a self-reference to `pdf-visual-compare`. That means `npm run test:types` still requires `./out/` to be current. Run `npm test` for the full validation path; use `npm run build` first if you want to execute the published-surface checks directly.
+
+## Mistake Logging
+
+Log one compact event per mistake (20-40 tokens, no filler):
+
+```text
+Ctx:
+Err:
+Cause:
+Fix:
+Rule:
+```
+
+Store project-specific mistakes in this `AGENTS.md` file under this section; keep generalizable rules in global memory. Do not rely on an uncommitted `.Codex/memory` path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,11 @@ First 4.x release — a major release with breaking changes to the supported Nod
 
 ### Changed
 
-- **BREAKING:** Minimum Node.js raised from `>=20` to `>=24` (aligns with `pdf-to-png-converter` 4.x).
-- **BREAKING:** `ComparePdfOptions.pdfToPngConvertOptions` is now typed as the library-owned `PdfRenderOptions` instead of the downstream `PdfToPngOptions`. It is narrowed to comparison-safe render settings — runtime attempts to disable page content or enable parallel rendering are rejected.
+- **BREAKING:** Minimum Node.js raised from `>=20` to `>=24` (required by the bundled `@napi-rs/canvas` native binaries pulled in through `pdf-to-png-converter` 4.x).
+- **BREAKING:** `ComparePdfOptions.pdfToPngConvertOptions` is now typed as the library-owned `PdfRenderOptions` instead of the downstream `PdfToPngOptions`. It is narrowed to comparison-safe render settings — the downstream rendering-control properties `returnPageContent`, `returnMetadataOnly`, `processPagesInParallel`, and `concurrencyLimit` are rejected at runtime with a `ComparePdfConfigurationError`.
 - **BREAKING:** `excludedAreas` entries are now typed via `PageExclusion` (`ExcludedPageArea` remains exported), with area and color fields using the library-owned `PageArea` and `RgbColor` types instead of downstream types.
 - `comparePdf` now accepts `Buffer` as an explicit input type in addition to `string` and `ArrayBufferLike`.
-- Upgraded runtime dependencies: `pdf-to-png-converter` `3.18.x` → `~4.1.1` and `png-visual-compare` `~5.1.0` → `~6.2.0`; with the latter, `ExcludedPageArea.excludedAreaColor` is now applied at render time.
+- Upgraded runtime dependencies: `pdf-to-png-converter` `~3.18.0` → `~4.1.1` and `png-visual-compare` `~5.1.0` → `~6.2.0`; with the latter, `ExcludedPageArea.excludedAreaColor` is now applied at render time.
 - Updated the package description to present the library as a PDF visual comparison tool with no external system package dependencies.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,38 @@ All notable user-visible changes to this project will be documented in this file
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/).
 
-> Historical release notes were not previously maintained in this repository. The seeded entries below include only details that are supportable from the current repository state and git history.
+> Historical release notes were not previously maintained in this repository. The entries below include only details that are supportable from the current repository state and git history.
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-06-19
+
+First 4.x release — a major release with breaking changes to the supported Node.js runtime, supported platforms, and public type surface, alongside a substantially expanded API. All changes below are relative to the last published release, 3.5.0.
+
+### Added
+
+- `comparePdfDetailed(actualPdf, expectedPdf, opts?)` — returns a structured, page-level comparison result (`ComparePdfDetailedResult`) alongside the existing boolean-returning `comparePdf`.
+- Error class hierarchy for programmatic handling: `ComparePdfError` (base) plus `ComparePdfInputError`, `ComparePdfConfigurationError`, `ComparePdfRenderingError`, and `ComparePdfComparisonError`.
+- New exported result types: `ComparePdfDetailedResult`, `ComparePdfPageResult`, and `ComparePdfPageStatus`.
+- New exported input/option types that decouple the public API from downstream dependencies: `PdfInput`, `PdfRenderOptions`, `PageExclusion`, `PageArea`, and `RgbColor`.
+- `ComparePdfOptions.allowedInputRoot` — constrains string PDF input paths to a trusted directory root for untrusted callers.
+- `ComparePdfOptions.writeDiffs` — explicit control over whether diff PNGs are written to disk.
+- `os` package metadata field declaring `darwin` and `linux` as the supported platforms.
+
 ### Changed
 
-- Narrowed `PdfRenderOptions` to comparison-safe render settings and reject runtime attempts to disable page content or enable parallel rendering.
-
-## [4.0.0] - 2026-04-24
+- **BREAKING:** Minimum Node.js raised from `>=20` to `>=24` (aligns with `pdf-to-png-converter` 4.x).
+- **BREAKING:** `ComparePdfOptions.pdfToPngConvertOptions` is now typed as the library-owned `PdfRenderOptions` instead of the downstream `PdfToPngOptions`. It is narrowed to comparison-safe render settings — runtime attempts to disable page content or enable parallel rendering are rejected.
+- **BREAKING:** `excludedAreas` entries are now typed via `PageExclusion` (`ExcludedPageArea` remains exported), with area and color fields using the library-owned `PageArea` and `RgbColor` types instead of downstream types.
+- `comparePdf` now accepts `Buffer` as an explicit input type in addition to `string` and `ArrayBufferLike`.
+- Upgraded runtime dependencies: `pdf-to-png-converter` `3.18.x` → `~4.1.1` and `png-visual-compare` `~5.1.0` → `~6.2.0`; with the latter, `ExcludedPageArea.excludedAreaColor` is now applied at render time.
+- Updated the package description to present the library as a PDF visual comparison tool with no external system package dependencies.
 
 ### Removed
 
-- Windows support. The package now declares Linux and macOS as the supported operating systems.
+- **BREAKING:** Windows support. The internal `pdfToPngWindowsCompat` module was removed, and the package now declares only `darwin` and `linux` in `os`.
 
-### Changed
+### Security
 
-- Updated package metadata and project documentation to describe the library as a PDF visual comparison tool with no external system package dependencies.
+- Added `allowedInputRoot` sandboxing with symlink rejection for string PDF input paths (CWE-59 / CWE-61).
+- Hardened `diffsOutputFolder` and `pdfToPngConvertOptions.outputFolder` against symlink traversal and validate→use (TOCTOU) races (CWE-367); diff PNGs are now written via a tempfile and atomically renamed into place.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
                 "linux"
             ],
             "dependencies": {
-                "pdf-to-png-converter": "~4.1.0",
-                "png-visual-compare": "~6.1.0"
+                "pdf-to-png-converter": "~4.1.1",
+                "png-visual-compare": "~6.2.0"
             },
             "devDependencies": {
-                "@types/node": "^25.9.2",
+                "@types/node": "^26.0.0",
                 "@types/pngjs": "^6.0.5",
-                "@vitest/coverage-v8": "^4.1.8",
+                "@vitest/coverage-v8": "^4.1.9",
                 "eslint": "^10.5.0",
                 "jiti": "^2.7.0",
                 "prettier": "~3.8.4",
@@ -444,6 +444,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -463,6 +466,9 @@
             "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -484,6 +490,9 @@
             "cpu": [
                 "riscv64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -504,6 +513,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -523,6 +535,9 @@
             "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -929,13 +944,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.9.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-            "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+            "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": ">=7.24.0 <7.24.7"
+                "undici-types": "~8.3.0"
             }
         },
         "node_modules/@types/pngjs": {
@@ -1323,9 +1338,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -1373,9 +1388,9 @@
             }
         },
         "node_modules/ast-v8-to-istanbul": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
-            "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+            "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -2332,9 +2347,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.13",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+            "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
             "devOptional": true,
             "funding": [
                 {
@@ -2358,15 +2373,18 @@
             "license": "MIT"
         },
         "node_modules/obug": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
             "devOptional": true,
             "funding": [
                 "https://github.com/sponsors/sxzz",
                 "https://opencollective.com/debug"
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
         },
         "node_modules/optionator": {
             "version": "0.9.4",
@@ -2470,9 +2488,9 @@
             "license": "MIT"
         },
         "node_modules/pdf-to-png-converter": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/pdf-to-png-converter/-/pdf-to-png-converter-4.1.0.tgz",
-            "integrity": "sha512-+I45h0VDefXK3wJ6VdCg4XmRPIEV90OEBhEFHXY98vOUvKdkNky8FK2i0+0nz8RXTc1K0qE6XsAiqfpfnU3a2w==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/pdf-to-png-converter/-/pdf-to-png-converter-4.1.1.tgz",
+            "integrity": "sha512-9DKVx0qgg9AIMoXtrjkfZ0GsCMXwcaBbM4iINdH9Md1lg9sfzTF/UovJgtIDd7SKG4nTGXJ2ooedsvw55VoUig==",
             "license": "MIT",
             "dependencies": {
                 "@napi-rs/canvas": "~1.0.0",
@@ -2533,9 +2551,9 @@
             }
         },
         "node_modules/png-visual-compare": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/png-visual-compare/-/png-visual-compare-6.1.0.tgz",
-            "integrity": "sha512-m4FIY9ZlvyUje/MnamFD+dp6hN803OuHEWDIpJKEMlksaXfK4bK3fZ6wrzOoPbqoLbislUjU9ioHWmQzvCg/ig==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/png-visual-compare/-/png-visual-compare-6.2.0.tgz",
+            "integrity": "sha512-yEYZR0SEPwSUhxvuIfv1TqvvknsEY9vRV2QE2RGQ/juF2a5qXJLo0ep3GWs6YMB4jMJiZaPSeEIs0OD3vFFd+Q==",
             "license": "MIT",
             "os": [
                 "darwin",
@@ -2694,9 +2712,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
             "devOptional": true,
             "license": "ISC",
             "bin": {
@@ -2889,9 +2907,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
             "devOptional": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "author": "Igor Magdich <magdich.igor@gmail.com>",
     "exports": {
         ".": {
-            "require": "./out/index.js",
             "types": "./out/index.d.ts",
+            "require": "./out/index.js",
             "default": "./out/index.js"
         }
     },

--- a/package.json
+++ b/package.json
@@ -62,13 +62,13 @@
         "test:types": "tsc --pretty -p ./tsconfig.json"
     },
     "dependencies": {
-        "pdf-to-png-converter": "~4.1.0",
-        "png-visual-compare": "~6.1.0"
+        "pdf-to-png-converter": "~4.1.1",
+        "png-visual-compare": "~6.2.0"
     },
     "devDependencies": {
-        "@types/node": "^25.9.2",
+        "@types/node": "^26.0.0",
         "@types/pngjs": "^6.0.5",
-        "@vitest/coverage-v8": "^4.1.8",
+        "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
         "jiti": "^2.7.0",
         "prettier": "~3.8.4",


### PR DESCRIPTION
## Release v4.0.0 + migrate npm publish to OIDC trusted publishing

First **4.x** release. `package.json` was already at `4.0.0` (set in "drop Windows support") but **never published** — npm `latest` is still `3.5.0` and there is no `v4` tag. This PR bundles the outstanding work and migrates publishing to OIDC trusted publishing so the release can be cut.

### Version rationale (3.5.0 → 4.0.0)
A major bump is required and sufficient. Verified against the published `3.5.0` surface:
- `engines.node` `>=20` → `>=24`; `os` now restricted to `darwin`/`linux` (Windows dropped) — **breaking**
- runtime deps: `pdf-to-png-converter` `3.18.x` → `~4.1.1`, `png-visual-compare` `~5.1.0` → `~6.2.0` — major bumps
- new public API: `comparePdfDetailed`, 5 error classes, 8 new exported types; `PdfRenderOptions` narrowed — **breaking + additive**

Because `4.0.0` was never published, all of the above (plus the dep patch/minor bumps in this PR) collapse into this single release — no version beyond `4.0.0` is warranted.

### Commits
- `chore(deps)` — `pdf-to-png-converter ~4.1.1`, `png-visual-compare ~6.2.0`, `@types/node ^26`, `@vitest/coverage-v8 ^4.1.9` + lockfile
- `ci` — **OIDC trusted publishing**: removed `NODE_AUTH_TOKEN`/`NPM_TOKEN` (no long-lived token needed; `id-token: write` already granted), added `npm install -g npm@latest` to guarantee npm CLI ≥ 11.5.1, set `package-manager-cache: false` for the release build; `--provenance` retained (now also automatic under trusted publishing)
- `docs` — `AGENTS.md` contributor guidance (repo-only; `files` ships only `./out`, so not in the published package)
- `docs` — full `[4.0.0]` CHANGELOG rewrite covering the complete breaking + feature surface

### Verification
Local `npm test` (the same gate CI runs) is **green**:
- clean → lint → codemap:check → license check → build → test:types → test:artifacts
- vitest: **30 files / 168 tests passed**; coverage **100% statements / 100% branches / 100% functions / 100% lines**

### Release steps (after merge)
1. Merge this PR to `main` (puts the OIDC workflow live before the release fires).
2. Create a **GitHub Release** with tag **`v4.0.0`** → triggers `publish.yml` → OIDC publish (no token) + automatic provenance.
3. Verify `npm view pdf-visual-compare version` → `4.0.0` and the provenance attestation on the npm page.

### Notes / follow-ups
- npm trusted publisher confirmed: no GitHub Actions environment, workflow file = `publish.yml`.
- The repo `NPM_TOKEN` secret is now unused — optional cleanup (safe to delete after a successful OIDC publish).
- The CHANGELOG date is `2026-06-19`; adjust if the actual release day differs.
