### PR TITLE
build: migrate compiler workflow to TypeScript 7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ node ./out/cli.js a.pdf b.pdf  # Run the built CLI (published entry point: `npx 
 
 Tests have a 90-second timeout (`vitest.config.mjs`) because PDF-to-PNG conversion is slow. Coverage thresholds are enforced (100% statements/lines/functions, 90% branches).
 
+**Toolchain is split on purpose — do not "correct" the aliases.** `build` and `test:types` invoke the TypeScript 7 native compiler by full path (`node ./node_modules/@typescript/native/bin/tsc`), where `@typescript/native` is an npm alias for `typescript@7`. The `typescript` devDependency is itself an alias for `@typescript/typescript6`, because TypeScript 7 removed the legacy JavaScript compiler API that `scripts/generate-codemap.ts` (`createProgram` + TypeChecker) and `typescript-eslint` (peer range `<6.1.0`) still need. Replacing either alias with a plain `typescript` dependency breaks codemap generation and linting. In `node_modules/.bin`, `tsc` is TypeScript 7 and `tsc6` is TypeScript 6. See `docs/TYPESCRIPT_7_MIGRATION.md`.
+
 ## Architecture
 
 This is a small TypeScript library published to npm. Source lives in `src/`, compiled output goes to `out/` (the published artifact).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `toJsonReport(result)` and `toJUnitReport(result)` — serialize a `ComparePdfDetailedResult` to pretty JSON or a JUnit XML report (one `<testcase>` per page). Both are exported from the package entry point.
 - New exported type `ComparePdfSummary`.
 
+### Changed
+
+- Build toolchain: the published `out/` artifact and repository type checks are now produced by the TypeScript 7 native compiler instead of TypeScript 6. Emitted JavaScript and declaration files are byte-identical under both compilers, so there is no change to the published API, runtime behavior, or supported Node.js versions. TypeScript remains a development dependency only. See [docs/TYPESCRIPT_7_MIGRATION.md](docs/TYPESCRIPT_7_MIGRATION.md).
+
 ## [4.0.0] - 2026-06-19
 
 First 4.x release — a major release with breaking changes to the supported Node.js runtime, supported platforms, and public type surface, alongside a substantially expanded API. All changes below are relative to the last published release, 3.5.0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ node ./out/cli.js a.pdf b.pdf  # Run the built CLI (published entry point: `npx 
 
 Tests have a 90-second timeout (`vitest.config.mjs`) because PDF-to-PNG conversion is slow. Coverage thresholds are enforced (100% statements/lines/functions, 90% branches).
 
+**Toolchain is split on purpose — do not "correct" the aliases.** `build` and `test:types` invoke the TypeScript 7 native compiler by full path (`node ./node_modules/@typescript/native/bin/tsc`), where `@typescript/native` is an npm alias for `typescript@7`. The `typescript` devDependency is itself an alias for `@typescript/typescript6`, because TypeScript 7 removed the legacy JavaScript compiler API that `scripts/generate-codemap.ts` (`createProgram` + TypeChecker) and `typescript-eslint` (peer range `<6.1.0`) still need. Replacing either alias with a plain `typescript` dependency breaks codemap generation and linting. In `node_modules/.bin`, `tsc` is TypeScript 7 and `tsc6` is TypeScript 6. See `docs/TYPESCRIPT_7_MIGRATION.md`.
+
 ## Architecture
 
 This is a small TypeScript library published to npm. Source lives in `src/`, compiled output goes to `out/` (the published artifact).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,25 @@ cd pdf-visual-compare
 npm ci
 ```
 
+## TypeScript toolchain
+
+This repository uses two TypeScript packages side by side, installed under npm
+aliases:
+
+- `@typescript/native` is `typescript@7`. It compiles `npm run build` and
+  `npm run test:types`, which invoke it by full path
+  (`node ./node_modules/@typescript/native/bin/tsc`) so the compiler in use
+  never depends on install history.
+- `typescript` is `@typescript/typescript6`, which provides the TypeScript 6
+  compiler API. `typescript-eslint` and `scripts/generate-codemap.ts` both need
+  that API, and TypeScript 7 no longer exposes it.
+
+After `npm ci`, `node_modules/.bin/tsc` is TypeScript 7 and
+`node_modules/.bin/tsc6` is TypeScript 6. A globally installed `tsc` is neither,
+so prefer the repository scripts. Do not replace either alias with a plain
+`typescript` dependency — that breaks linting and codemap generation. See
+[docs/TYPESCRIPT_7_MIGRATION.md](docs/TYPESCRIPT_7_MIGRATION.md).
+
 ## Project layout
 
 - `src/` — library source

--- a/docs/TYPESCRIPT_7_MIGRATION.md
+++ b/docs/TYPESCRIPT_7_MIGRATION.md
@@ -1,0 +1,101 @@
+# TypeScript 7 Migration
+
+## Goal
+
+Use the TypeScript 7 native compiler for repository type-checking and package
+builds, while preserving the TypeScript 6 compiler API that the codemap
+generator and `typescript-eslint` still require.
+
+## Constraints
+
+- TypeScript 7.0 does not expose the legacy JavaScript compiler API. Its main
+  export is `./lib/version.cjs`; everything else is published under `unstable/*`
+  subpaths.
+- `scripts/generate-codemap.ts` imports `typescript` and uses `createProgram`
+  and the TypeChecker to build `CODEMAP.md`.
+- `typescript-eslint` 8.x declares a peer range of `typescript >=4.8.4 <6.1.0`.
+- TypeScript is a development dependency only. The published package exposes no
+  TypeScript dependency, so the split toolchain affects development and CI only.
+
+## Dependency layout
+
+| `devDependencies` entry | Resolves to                      | Purpose                                                         |
+| ----------------------- | -------------------------------- | --------------------------------------------------------------- |
+| `@typescript/native`    | `typescript@~7.0.2`              | Native compiler used by `build` and `test:types`                |
+| `typescript`            | `@typescript/typescript6@~6.0.2` | TypeScript 6 compiler API used by ESLint and the codemap script |
+
+The compatibility package depends on `@typescript/old` (`npm:typescript@^6`),
+which supplies the real TypeScript 6.0.3 implementation and the `tsserver`
+binary. Binary names do not collide: the compatibility package publishes its own
+compiler as `tsc6`, so a clean `npm ci` links `node_modules/.bin/tsc` to the
+native compiler.
+
+The `build` and `test:types` scripts nonetheless invoke the native compiler by
+its full package path so compiler selection cannot drift with install history:
+
+```sh
+node ./node_modules/@typescript/native/bin/tsc --pretty -p ./tsconfig.prod.json
+node ./node_modules/@typescript/native/bin/tsc --pretty -p ./tsconfig.json
+```
+
+Both ranges are tilde-pinned. A TypeScript 7 minor release can introduce new
+type errors, and the compatibility package must stay inside the support window
+that `typescript-eslint` declares.
+
+## Source and configuration changes
+
+None. `tsconfig.json` and `tsconfig.prod.json` type-check clean under
+TypeScript 7 without modification, and no source file needed changes.
+
+## Editor configuration
+
+`.vscode/` is not tracked in this repository, so editor settings must be adjusted
+locally. If your `.vscode/settings.json` sets
+`"typescript.tsdk": "node_modules/typescript/lib"`, remove that entry. The path
+now resolves to the compatibility package, whose `lib/` contains no
+`tsserver.js`, so VS Code cannot start a workspace TypeScript service from it.
+The native package ships no language server either — its editor support is a
+separate extension. Without the setting, VS Code falls back to its bundled
+TypeScript.
+
+## Verification
+
+Performed on 2026-07-29 with Node.js 24.18.0 and npm 12.0.1:
+
+- Emitted output is byte-identical between TypeScript 6.0.3 and TypeScript 7.0.2.
+  Both compilers built `tsconfig.prod.json` into separate directories; `diff -r`
+  reported no differences across all 82 emitted files, and the `out/cli.js`
+  shebang is preserved.
+- `node_modules` was deleted and `npm ci` run from the regenerated lockfile:
+  `typescript` resolves to `@typescript/typescript6@6.0.2`, `require('typescript').version`
+  reports `6.0.3` with `createProgram` present, and the native compiler reports
+  `Version 7.0.2`.
+- `npm test` passed end to end: clean, lint, codemap check, license check,
+  build, type check, artifact check, and Vitest with coverage thresholds.
+- `npm pack --dry-run` passed with package contents limited to `out`.
+
+### Installation note
+
+A plain `npm install` after editing `package.json` retained the previously
+locked `typescript@6.0.3` instead of substituting the compatibility alias. The
+alias had to be installed explicitly:
+
+```sh
+npm install --save-dev "typescript@npm:@typescript/typescript6@~6.0.2"
+```
+
+A subsequent clean `npm ci` confirmed the corrected lockfile is reproducible.
+
+## Follow-up
+
+Reassess once TypeScript 7.1 provides a stable compiler API and
+`typescript-eslint` declares support for it. At that point, try replacing both
+aliases with a single plain `typescript@7` dependency, restore the plain `tsc`
+invocations, and remove this compatibility layout if codemap generation,
+linting, and the full test suite pass.
+
+## Rollback
+
+Remove `@typescript/native`, restore `typescript` to `~6.0.3`, revert the
+`build` and `test:types` scripts to plain `tsc`, regenerate the lockfile, and
+rerun the verification steps above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,12 +22,13 @@
             "devDependencies": {
                 "@types/node": "^26.0.0",
                 "@types/pngjs": "^6.0.5",
+                "@typescript/native": "npm:typescript@~7.0.2",
                 "@vitest/coverage-v8": "^4.1.9",
                 "eslint": "^10.5.0",
                 "jiti": "^2.7.0",
                 "prettier": "~3.9.4",
                 "rimraf": "^6.1.3",
-                "typescript": "^6.0.3",
+                "typescript": "npm:@typescript/typescript6@~6.0.2",
                 "typescript-eslint": "^8.61.1",
                 "vitest": "^4.1.9"
             },
@@ -1194,6 +1195,397 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript/native": {
+            "name": "typescript",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc"
+            },
+            "engines": {
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/typescript-aix-ppc64": "7.0.2",
+                "@typescript/typescript-darwin-arm64": "7.0.2",
+                "@typescript/typescript-darwin-x64": "7.0.2",
+                "@typescript/typescript-freebsd-arm64": "7.0.2",
+                "@typescript/typescript-freebsd-x64": "7.0.2",
+                "@typescript/typescript-linux-arm": "7.0.2",
+                "@typescript/typescript-linux-arm64": "7.0.2",
+                "@typescript/typescript-linux-loong64": "7.0.2",
+                "@typescript/typescript-linux-mips64el": "7.0.2",
+                "@typescript/typescript-linux-ppc64": "7.0.2",
+                "@typescript/typescript-linux-riscv64": "7.0.2",
+                "@typescript/typescript-linux-s390x": "7.0.2",
+                "@typescript/typescript-linux-x64": "7.0.2",
+                "@typescript/typescript-netbsd-arm64": "7.0.2",
+                "@typescript/typescript-netbsd-x64": "7.0.2",
+                "@typescript/typescript-openbsd-arm64": "7.0.2",
+                "@typescript/typescript-openbsd-x64": "7.0.2",
+                "@typescript/typescript-sunos-x64": "7.0.2",
+                "@typescript/typescript-win32-arm64": "7.0.2",
+                "@typescript/typescript-win32-x64": "7.0.2"
+            }
+        },
+        "node_modules/@typescript/old": {
+            "name": "typescript",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/@typescript/typescript-aix-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+            "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+            "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+            "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+            "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+            "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+            "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-loong64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+            "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-mips64el": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+            "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+            "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-riscv64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+            "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-s390x": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+            "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+            "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-sunos-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+            "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+            "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+            "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
             }
         },
         "node_modules/@vitest/coverage-v8": {
@@ -2872,17 +3264,17 @@
             }
         },
         "node_modules/typescript": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "name": "@typescript/typescript6",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+            "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
             "dev": true,
             "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
+            "dependencies": {
+                "@typescript/old": "npm:typescript@^6"
             },
-            "engines": {
-                "node": ">=14.17"
+            "bin": {
+                "tsc6": "bin/tsc6"
             }
         },
         "node_modules/typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     ],
     "scripts": {
         "prebuild": "npm run clean",
-        "build": "tsc --pretty -p ./tsconfig.prod.json",
+        "build": "node ./node_modules/@typescript/native/bin/tsc --pretty -p ./tsconfig.prod.json",
         "clean": "rimraf ./out ./coverage ./test-results ./comparePdfOutput",
         "codemap": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/generate-codemap.ts",
         "codemap:check": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/generate-codemap.ts --check",
@@ -62,7 +62,7 @@
         "test:artifacts": "node ./__tests__/published-artifacts/verify-built-package.mjs",
         "test:docker": "npm run docker:build && npm run docker:run",
         "test:license": "npx --yes license-checker --production --onlyAllow \"ISC; MIT; MIT OR X11; BSD; Apache-2.0; Unlicense; MPL-2.0\"",
-        "test:types": "tsc --pretty -p ./tsconfig.json"
+        "test:types": "node ./node_modules/@typescript/native/bin/tsc --pretty -p ./tsconfig.json"
     },
     "dependencies": {
         "pdf-to-png-converter": "~4.1.1",
@@ -71,12 +71,13 @@
     "devDependencies": {
         "@types/node": "^26.0.0",
         "@types/pngjs": "^6.0.5",
+        "@typescript/native": "npm:typescript@~7.0.2",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
         "jiti": "^2.7.0",
         "prettier": "~3.9.4",
         "rimraf": "^6.1.3",
-        "typescript": "^6.0.3",
+        "typescript": "npm:@typescript/typescript6@~6.0.2",
         "typescript-eslint": "^8.61.1",
         "vitest": "^4.1.9"
     },


### PR DESCRIPTION
## Summary

Moves repository type-checking and the production build onto the **TypeScript 7.0.2 native compiler**, while keeping the TypeScript 6 compiler API available to the tooling that still needs it. Same approach as `png-visual-compare` [#125](https://github.com/dichovsky/png-visual-compare/pull/125), adapted to this repository.

**Supersedes #84** (`chore(deps-dev): bump typescript from 6.0.3 to 7.0.2`), which is red — a plain version bump cannot work here, for the reason below.

## Why a plain upgrade fails

TypeScript 7 removed the legacy JavaScript compiler API. The published package's main export is now `./lib/version.cjs`, with everything else behind `unstable/*` subpaths. Two consumers in this repository still need the old API:

- `scripts/generate-codemap.ts` — `import * as ts from 'typescript'`, then `createProgram` plus the TypeChecker to build `CODEMAP.md`
- `typescript-eslint` — declares a peer range of `typescript >=4.8.4 <6.1.0` (still true on the latest 8.65.0)

## Approach

Both compilers are installed side by side under npm aliases:

| `devDependencies` entry | Resolves to | Serves |
| --- | --- | --- |
| `@typescript/native` | `typescript@~7.0.2` | `build`, `test:types` |
| `typescript` | `@typescript/typescript6@~6.0.2` | `typescript-eslint`, codemap generator |

`build` and `test:types` invoke the native compiler by full package path (`node ./node_modules/@typescript/native/bin/tsc`). A clean `npm ci` does link `node_modules/.bin/tsc` to TypeScript 7 — the compatibility package names its own binary `tsc6` to avoid the clash — but the explicit path means compiler selection can never drift with install history.

Both ranges are tilde-pinned: a TypeScript 7 minor can introduce new type errors, and the compatibility package must stay inside the support window `typescript-eslint` declares.

**No source or `tsconfig` changes.** Both configs type-check clean under TypeScript 7 as-is.

## Verification

Run with Node.js 24.17.0 / npm 11.17.0 (matching what CI resolves from `.nvmrc`):

- **Emit is byte-identical.** Both compilers built `tsconfig.prod.json` into separate directories; `diff -r` reported zero differences across all 82 emitted files, and the `out/cli.js` shebang is preserved. The published artifact is unchanged.
- **Lockfile is reproducible.** `node_modules` deleted and `npm ci` run from the regenerated lockfile: `typescript` resolves to `@typescript/typescript6@6.0.2`, `require('typescript').version` reports `6.0.3` with `createProgram` present, and the native compiler reports `Version 7.0.2`. `lockfileVersion` stays at 3.
- **`npm test` passes end to end** (exit 0): clean, lint, codemap check, license check, build, type check, artifact check, then Vitest — 41 test files, coverage 100% statements / 100% branches / 100% functions / 100% lines.
- **`npm pack --dry-run`** passes, 85 files, contents limited to `out`.

### Installation note

A plain `npm install` after editing `package.json` retained the previously locked `typescript@6.0.3` rather than substituting the alias — the same trap `png-visual-compare` #125 hit. The alias had to be installed explicitly (`npm install --save-dev "typescript@npm:@typescript/typescript6@~6.0.2"`), after which a clean `npm ci` confirmed the corrected lockfile.

## Documentation

- `docs/TYPESCRIPT_7_MIGRATION.md` — layout, verification, rollback, and the TypeScript 7.1 follow-up trigger for deleting the compatibility layer
- `CONTRIBUTING.md` — toolchain section (`tsc` is 7, `tsc6` is 6, don't unalias)
- `CLAUDE.md` / `AGENTS.md` — constraint note, so an agent asked to "update dependencies" doesn't helpfully revert the alias
- `CHANGELOG.md` — `[Unreleased] / Changed`, recording build provenance for the published artifact

`.vscode/` is untracked, so it isn't touched here. Contributors with `"typescript.tsdk": "node_modules/typescript/lib"` set locally should remove it — that path is now the compatibility package, which contains no `tsserver.js`.

## Follow-ups (not in this PR)

1. **`test:artifacts` is incompatible with npm 12.** `__tests__/published-artifacts/verify-built-package.mjs:31` does `const [packResult] = JSON.parse(packOutput)`, but npm 12 changed `npm pack --json` from an array to an object keyed by package name, giving `TypeError: object is not iterable`. Unrelated to this PR and reproducible on `main`. It doesn't affect CI yet (Node 24.17.0 bundles npm 11.17.0; 24.18.0 bundles npm 12.0.1), but `publish.yml` runs `npm install -g npm@latest` before `prepublishOnly`, so **the release pipeline is already exposed**.
2. `npm run format:check` fails on `main` for 10 pre-existing files and is not part of the `npm test` pipeline. Left alone here; this PR adds no new violations.
3. `CONTRIBUTING.md`'s "What `npm test` covers" list omits `npm run codemap:check`, which `pretest` does run.
